### PR TITLE
Set sensible floor for client difficulty and ensure padding doesn't crash the system

### DIFF
--- a/main.go
+++ b/main.go
@@ -604,6 +604,7 @@ func (client *StratumClient) SendDifficulty() {
 	}
 
 	clientDiff := upstreamDiff * client.VarDiff
+	clientDiff = math.Max(0.01, clientDiff) // Don't allow diff to drop below 0.01
 	if client.Difficulty != clientDiff {
 		logging.Infof("Setting difficulty for client %d to %0.9f", client.ID, clientDiff)
 		client.conn.Outgoing <- stratum.StratumMessage{
@@ -643,7 +644,7 @@ func (client *StratumClient) AdjustDiffIfNeeded() {
 		spm := float64(client.ShareCount) / mins
 		if spm < 6 || spm > 14 {
 			client.VarDiff = math.Min(1, client.VarDiff*(spm/float64(10))) // Don't make downstream more difficult than upstream ever
-			logging.Infof("Adjusting difficulty for client %d to %0.9f", client.ID, client.VarDiff)
+			logging.Infof("Adjusting difficulty for client %d to %0.9f. spm: %0.9f", client.ID, client.VarDiff, spm)
 			diffCacheLock.Lock()
 			diffCache[client.Username] = client.VarDiff
 			diffCacheLock.Unlock()
@@ -1033,8 +1034,12 @@ func diffToTarget(diff float64) *big.Int {
 
 func padTo32(b []byte) []byte {
 	b2 := make([]byte, 32)
-	copy(b2[32-len(b):], b)
-	return b2
+	if len(b) < 32 {
+		copy(b2[32-len(b):], b)
+		return b2
+	}
+
+	return b
 }
 
 func processPayouts() {


### PR DESCRIPTION
Fixes the following two issues:

```
021/01/27 02:56:04 [INFO] Share target : 922b781e1bf21000000000000000000000000000000000000000000000000000
2021/01/27 02:56:04 [INFO] Reward share : 0.000000009
2021/01/27 02:56:04 [INFO] Reward       : 46
2021/01/27 02:56:04 [INFO] New difficulty received: 0.408871
2021/01/27 02:56:04 [INFO] Received new job from upstream: 21886919677894328045694790038881678858
2021/01/27 02:56:04 [DEBUG] Sending client 1 new job 21886919677894328045694790038881678858
2021/01/27 02:56:04 [INFO] Setting difficulty for client 1 to 0.000000031
2021/01/27 02:56:06 [INFO] Subsidy      : 5000000000
2021/01/27 02:56:06 [INFO] Block target : 00000017390d0000000000000000000000000000000000000000000000000000
2021/01/27 02:56:06 [INFO] Upstream target : 000002721b000000000000000000000000000000000000000000000000000000
panic: runtime error: slice bounds out of range [-1:]

goroutine 37 [running]:
main.padTo32(...)
    /go/src/github.com/gertjaap/p2proxy/main.go:1036
main.processShares()
    /go/src/github.com/gertjaap/p2proxy/main.go:396 +0x12e5
created by main.main
    /go/src/github.com/gertjaap/p2proxy/main.go:170 +0x4d6
```

```
2021/01/27 04:51:41 [INFO] Setting difficulty for client 2 to 0.000000000
2021/01/27 04:51:41 [INFO] New difficulty received: 0.317301
2021/01/27 04:51:41 [INFO] Received new job from upstream: 76258072535426889482685517921425137458
2021/01/27 04:51:41 [DEBUG] Sending client 2 new job 76258072535426889482685517921425137458
2021/01/27 04:51:44 [INFO] Subsidy      : 5000000000
2021/01/27 04:51:44 [INFO] Block target : 00000015e9df0000000000000000000000000000000000000000000000000000
2021/01/27 04:51:44 [INFO] Upstream target : 00000326cb000000000000000000000000000000000000000000000000000000
2021/01/27 04:51:44 [INFO] Share target : 01b49566da182b5000000000000000000000000000000000000000000000000000000000000000
2021/01/27 04:51:44 [INFO] Reward share : 0.000000000
2021/01/27 04:51:44 [INFO] Reward       : 0
```